### PR TITLE
write user_db data to system

### DIFF
--- a/src/subscription/change.c
+++ b/src/subscription/change.c
@@ -725,5 +725,5 @@ out:
 
 	ctx->temp_users.created = ctx->temp_users.modified = ctx->temp_users.deleted = NULL;
 
-	return SR_ERR_CALLBACK_FAILED;
+	return error;
 }

--- a/src/system/api/authentication/change.c
+++ b/src/system/api/authentication/change.c
@@ -140,6 +140,12 @@ int system_authentication_user_apply_changes(system_ctx_t *ctx)
 		}
 	}
 
+	error = um_db_store(user_db);
+	if (error) {
+		SRPLG_LOG_ERR(PLUGIN_NAME, "um_db_store() error (%d)", error);
+		goto error_out;
+	}
+
 	// after user changes handle authentication changes
 
 #endif


### PR DESCRIPTION
otherwise the change callback fails and the datastore doesn't get updated

fixes `change` from https://github.com/telekom/sysrepo-plugin-system/issues/6