### PR TITLE
Fix build on non-systemd systems

### DIFF
--- a/src/core/api/system/dns_resolver/load.c
+++ b/src/core/api/system/dns_resolver/load.c
@@ -19,7 +19,9 @@
 #include "core/data/system/dns_resolver/search/list.h"
 #include "core/data/system/ip_address.h"
 
+#ifdef SYSTEMD
 #include <systemd/sd-bus.h>
+#endif
 
 #include <sysrepo.h>
 

--- a/src/core/api/system/dns_resolver/store.c
+++ b/src/core/api/system/dns_resolver/store.c
@@ -13,7 +13,9 @@
 #include "store.h"
 #include "core/common.h"
 
+#ifdef SYSTEMD
 #include <systemd/sd-bus.h>
+#endif
 
 #include <sysrepo.h>
 


### PR DESCRIPTION
Very minor and obvious fix, the code already has the `#ifdef SYSTEMD`, was only missing for the includes.
