### PR TITLE
Fix unconditional error return when enabling ntp server

### DIFF
--- a/src/plugin/subscription/change.c
+++ b/src/plugin/subscription/change.c
@@ -213,7 +213,7 @@ error_out:
 	error = SR_ERR_CALLBACK_FAILED;
 
 out:
-	return SR_ERR_CALLBACK_FAILED;
+	return error;
 }
 
 int system_subscription_change_ntp_server(sr_session_ctx_t *session, uint32_t subscription_id, const char *module_name, const char *xpath, sr_event_t event, uint32_t request_id, void *private_data)
@@ -368,7 +368,7 @@ out:
 
 	system_ntp_server_list_free(&ctx->temp_ntp_servers);
 
-	return SR_ERR_CALLBACK_FAILED;
+	return error;
 }
 
 int system_subscription_change_dns_resolver_search(sr_session_ctx_t *session, uint32_t subscription_id, const char *module_name, const char *xpath, sr_event_t event, uint32_t request_id, void *private_data)


### PR DESCRIPTION
When ntp-server tries to transition state from `disabled` to `enabled`,  an unconditional  return of `SR_ERR_CALLBACK_FAILED`  causes NETCONF server to report an error. Note that `systemctl` successfully enables and starts the `ntp.service`, which then works as intended.
This PR simply returns the correct variables instead of constants.